### PR TITLE
N/A: Fix package resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.7.0",
   "description": "A collection of devices indexed by their identifiers.",
   "main": "./dist/index.js",
+  "exports": {
+    "default": "./lib/index.ts"
+  },
   "scripts": {
     "prepare": "tsc",
     "lint": "prettier --check .",


### PR DESCRIPTION
<!-- If this is not ready to be reviewed create a draft pull request -->
# Summary
<!-- Include a summary of the change and which issue is fixed -->

Fix package resolution

## Description
Due to the addition of `main` property on the `package.json` pointing to a non-existing directory, it resolves on wrong package resolution on CGA Frontend.

This helps ESBuild find the right code location and transpile it to JavaScript.

## Type of change
<!-- These are only examples you can change these however it fits -->

- Bug fix (non-breaking change which fixes an issue)
